### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,8 @@
-from pip.req import parse_requirements
+#from pip.req import parse_requirements
+try: # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
 from setuptools import setup
 
 install_requirements = parse_requirements('./requirements.txt', session=False)


### PR DESCRIPTION
Instead of " from pip.req import parse_requirements"  we can use "try: # for pip >= 10
    from pip._internal.req import parse_requirements
except ImportError: # for pip <= 9.0.3
    from pip.req import parse_requirements " to avoid the  No module named pip.req Error