### PR TITLE
Add support for codemirror schema

### DIFF
--- a/xsdtojson/__init__.py
+++ b/xsdtojson/__init__.py
@@ -3,4 +3,4 @@
 """
 Created by Ben Scott on '25/01/2017'.
 """
-from xsdtojson.lib import xsd_to_json_schema
+from .lib import xsd_to_json_schema

--- a/xsdtojson/cli.py
+++ b/xsdtojson/cli.py
@@ -1,6 +1,6 @@
 import click
 from pygments import highlight, lexers, formatters
-from xsdtojson import xsd_to_json_schema
+from .lib import xsd_to_json_schema
 
 
 @click.command()

--- a/xsdtojson/lib.py
+++ b/xsdtojson/lib.py
@@ -3,14 +3,15 @@
 """
 Created by Ben Scott on '25/01/2017'.
 """
-from xsdtojson.xsd_parser import XSDParser
+from .xsd_parser import XSDParser
 
 
-def xsd_to_json_schema(xsd_src):
+def xsd_to_json_schema(xsd_src, code_mirror_format=False):
     """
     Helper function for instigating XSDParser and parsing file
     :param xsd_src: Path to XSD file / string
+    :param code_mirror_format: Either using codemirror json format or not
     :return:
     """
     xsd_parser = XSDParser(xsd_src)
-    return xsd_parser.json_schema()
+    return xsd_parser.json_schema(code_mirror_format=code_mirror_format)

--- a/xsdtojson/xsd_parser.py
+++ b/xsdtojson/xsd_parser.py
@@ -116,7 +116,7 @@ class XSDParser:
                 schema = schema['properties'][first_property]
         return schema
 
-    def json_schema(self):
+    def json_schema(self, code_mirror_format=False):
         """
         Main entry point - convert the XSD file to
         :return:
@@ -128,11 +128,33 @@ class XSDParser:
             self.parse_element_recurse(element, schema)
 
         # Flatten the schema - so if there's just one element at the root, this is removed
-        schema = self.flatten_schema(schema)
+        if code_mirror_format:
+            new_schema = self.format_codemirror(schema, topLevel=True)
+            for item in new_schema:
+                if isinstance(new_schema[item], set):
+                    new_schema[item] = list(new_schema[item])
+                if 'children' in new_schema[item] and isinstance(new_schema[item]['children'], set):
+                    new_schema[item]['children'] = list(new_schema[item]['children'])
+            schema = new_schema
+        else:
+            schema = self.flatten_schema(schema)
+
         # Set schema
         schema['schema'] = 'http://json-schema.org/schema#'
         schema['type'] = 'object'
         return json.dumps(schema, sort_keys=False, indent=4)
+
+    def format_codemirror(self, schema, tmp_schema=None, topLevel=False, parent=None):
+        items = schema['properties'] if 'properties' in schema else []
+        for item in items:
+            if topLevel:
+                tmp_schema = OrderedDict() if not tmp_schema else tmp_schema
+                tmp_schema.setdefault('!top', set([])).add(item)
+            if parent:
+                tmp_schema[parent]['children'].add(item)
+            tmp_schema.setdefault(item, OrderedDict()).setdefault('children', set())
+            self.format_codemirror(schema['properties'][item], tmp_schema=tmp_schema, parent=item)
+        return tmp_schema
 
     def xsd_to_json_schema_type(self, element_type):
         try:

--- a/xsdtojson/xsd_parser.py
+++ b/xsdtojson/xsd_parser.py
@@ -116,7 +116,7 @@ class XSDParser:
                 schema = schema['properties'][first_property]
         return schema
 
-    def json_schema(self, code_mirror_format=False):
+    def json_schema(self, code_mirror_format):
         """
         Main entry point - convert the XSD file to
         :return:


### PR DESCRIPTION
[Quick and dirty]
In order to use codemirror autocompletion for xml, we need to define a special **json schema** : 
```
"!top": ["toplevel"],
toplevel: {
    "children": ["sublevel", "sublevel2"]
},
sublevel: {
    "children": []
},
sublevel2: {
    "children": []
}
```
[An example here : `var tags = {...}`](https://github.com/codemirror/CodeMirror/blob/master/demo/xmlcomplete.html)

So I updated your code by adding a parameter to activate the codemirror format which override the initial built schema. 